### PR TITLE
travis: reduce the noise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,9 @@ matrix:
 
 notifications:
   email: false
-  irc: "irc.freenode.org#platal"
+  irc:
+    channels:
+      - "irc.freenode.org#platal"
+    on_success: change
+    on_failure: always
+    use_notice: true


### PR DESCRIPTION
Reduce travis noise for irc notifications:

- notify on build failure
- notify on build fixed
- keep silent if build did not break

The travis documentation explicitly states that the IRC notification is not triggered for pull requests, sadly. 😞 