### PR TITLE
Simple list/revoke consents view

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django-oidc-provider
+django-bootstrap4

--- a/xorgauth/accounts/models.py
+++ b/xorgauth/accounts/models.py
@@ -78,6 +78,12 @@ class User(base_user.AbstractBaseUser):
         """Staff members are defined by the admin role"""
         return self.roles.filter(hrid=ADMIN_ROLE_HRID).count() > 0
 
+    @property
+    def email(self):
+        """Hack to work around a bug in django-oidc-provider"""
+        field_name = self.get_email_field_name()
+        return getattr(self, field_name)
+
     def has_module_perms(self, app_label):
         # staff members have every right
         if self.is_staff:

--- a/xorgauth/accounts/models.py
+++ b/xorgauth/accounts/models.py
@@ -46,7 +46,7 @@ class UserManager(base_user.BaseUserManager):
 
 class User(base_user.AbstractBaseUser):
     uid = models.UUIDField("UUID", default=uuid.uuid4, editable=False)
-    hrid = models.SlugField(_("human-readable identifier"), unique=True)
+    hrid = models.SlugField(_("username"), unique=True)
     fullname = UnboundedCharField(_("full name"), help_text=_("Name to display to other users"))
     preferred_name = UnboundedCharField(_("preferred name"), help_text=_("Name used when addressing the user"))
     main_email = models.EmailField(_("email"), unique=True)

--- a/xorgauth/accounts/views.py
+++ b/xorgauth/accounts/views.py
@@ -1,0 +1,30 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+
+from oidc_provider.models import UserConsent, Client
+
+
+@login_required
+def list_consents(request):
+    # if a revoke request was done, process it
+    revoked_client = None
+    error = None
+    revoke = request.POST.get('revoke', None)
+    if revoke is not None:
+        consent = UserConsent.objects.filter(user=request.user, client__client_id=revoke)
+        if consent:
+            revoked_client = consent[0].client
+            consent[0].delete()
+        else:
+            client = Client.objects.filter(client_id=revoke)
+            if client:
+                error = "You have no consent for client \"{}\".".format(client[0].name)
+            else:
+                error = "Unknown client."
+    # render the result
+    consents = UserConsent.objects.filter(user=request.user)
+    return render(request, 'list_consents.html', {
+        'error': error,
+        'revoked_client': revoked_client,
+        'consents': consents
+    })

--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -38,8 +38,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.auth',
-    'oidc_provider',
     'xorgauth',
+    'oidc_provider',
 ]
 
 MIDDLEWARE = [

--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.auth',
     'xorgauth',
     'oidc_provider',
+    'bootstrap4',
 ]
 
 MIDDLEWARE = [

--- a/xorgauth/templates/base.html
+++ b/xorgauth/templates/base.html
@@ -1,4 +1,4 @@
-{% load i18n staticfiles %}
+{% load i18n staticfiles bootstrap4 %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -9,7 +9,10 @@
 
     <title>{% trans 'Polytechnique.org' %}</title>
 
-    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.2/css/bootstrap.min.css">
+    {% bootstrap_css %}
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    {% bootstrap_javascript %}
+
 </head>
 <body>
     <nav class="navbar navbar-fixed-top navbar-light bg-faded">

--- a/xorgauth/templates/list_consents.html
+++ b/xorgauth/templates/list_consents.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% load i18n staticfiles %}
+
+{% block content %}
+
+<div class="row">
+    <div class="col-md-6 col-md-offset-3">
+        {% if error %}
+            <div>Error: {{ error }}</div>
+        {% endif %}
+        {% if revoked_client %}
+            <div>Successfully revoked consent for client "{{ revoked_client }}".</div>
+        {% endif %}
+        <table>
+            <thead>
+                <tr><td>Client name</td><td>Authorized scopes</td><td>Expiration date</td><td></td></tr>
+            </thead>
+            <tbody>
+            {% for consent in consents %}
+            <tr>
+                <td>{{ consent.client.name }}</td>
+                <td>{{ consent.scope }}</td>
+                <td>{{ consent.expires_at }}</td>
+                <td>
+                    <form action="{{ request.path }}" method="POST">
+                        {% csrf_token %}
+                        <input type="hidden" name="revoke" value="{{ consent.client.client_id }}" />
+                        <input type="submit" value="Revoke" />
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+{% endblock %}

--- a/xorgauth/templates/list_consents.html
+++ b/xorgauth/templates/list_consents.html
@@ -1,38 +1,49 @@
 {% extends 'base.html' %}
-{% load i18n staticfiles %}
+{% load i18n staticfiles bootstrap4 %}
 
 {% block content %}
 
-<div class="row">
-    <div class="col-md-6 col-md-offset-3">
-        {% if error %}
-            <div>Error: {{ error }}</div>
-        {% endif %}
-        {% if revoked_client %}
-            <div>Successfully revoked consent for client "{{ revoked_client }}".</div>
-        {% endif %}
-        <table>
-            <thead>
-                <tr><td>Client name</td><td>Authorized scopes</td><td>Expiration date</td><td></td></tr>
-            </thead>
-            <tbody>
-            {% for consent in consents %}
-            <tr>
-                <td>{{ consent.client.name }}</td>
-                <td>{{ consent.scope }}</td>
-                <td>{{ consent.expires_at }}</td>
-                <td>
-                    <form action="{{ request.path }}" method="POST">
-                        {% csrf_token %}
-                        <input type="hidden" name="revoke" value="{{ consent.client.client_id }}" />
-                        <input type="submit" value="Revoke" />
-                    </form>
-                </td>
-            </tr>
-            {% endfor %}
-            </tbody>
-        </table>
+{% if error %}
+    <div class="alert alert-danger" role="alert">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+        Error: {{ error }}
     </div>
-</div>
+{% endif %}
+{% if revoked_client %}
+    <div class="alert alert-success" role="alert">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+        Successfully revoked consent for client "{{ revoked_client }}".
+    </div>
+{% endif %}
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th scope="col">Client name</th>
+            <th scope="col">Authorized scopes</th>
+            <th scope="col">Expiration date</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for consent in consents %}
+    <tr>
+        <td>{{ consent.client.name }}</td>
+        <td>{{ consent.scope }}</td>
+        <td>{{ consent.expires_at }}</td>
+        <td>
+            <form action="{{ request.path }}" method="POST">
+                {% csrf_token %}
+                <input type="hidden" name="revoke" value="{{ consent.client.client_id }}" />
+                <input type="submit" value="Revoke" class="btn btn-secondary" />
+            </form>
+        </td>
+    </tr>
+    {% endfor %}
+    </tbody>
+</table>
 
 {% endblock %}

--- a/xorgauth/templates/oidc_provider/authorize.html
+++ b/xorgauth/templates/oidc_provider/authorize.html
@@ -1,10 +1,10 @@
 {% extends 'base.html' %}
-{% load i18n staticfiles %}
+{% load i18n staticfiles bootstrap4 %}
 
 {% block content %}
 
 <div class="row">
-    <div class="col-md-6 col-md-offset-3">
+    <div class="col-md-6 offset-md-3">
         <h2>{% trans 'Request for Permission' %}</h2>
         <p class="lead">Client <i>{{ client.name }}</i> would like to access this information of you.</p>
         <form method="post" action="{% url 'oidc_provider:authorize' %}">

--- a/xorgauth/templates/oidc_provider/error.html
+++ b/xorgauth/templates/oidc_provider/error.html
@@ -3,7 +3,7 @@
 {% block content %}
 
 <div class="row">
-    <div class="col-md-6 col-md-offset-3">
+    <div class="col-md-6 offset-md-3">
         <h2>{{ error }}</h2>
         <p class="lead">{{ description }}</p>
     </div>

--- a/xorgauth/templates/registration/login.html
+++ b/xorgauth/templates/registration/login.html
@@ -1,26 +1,15 @@
 {% extends "base.html" %}
+{% load bootstrap4 %}
 
 {% block content %}
 
-{% if form.errors %}
-<p>Your username and password didn't match. Please try again.</p>
-{% endif %}
-
-<form method="post" action="{% url 'login' %}">
-{% csrf_token %}
-<table>
-<tr>
-    <td>{{ form.username.label_tag }}</td>
-    <td>{{ form.username }}</td>
-</tr>
-<tr>
-    <td>{{ form.password.label_tag }}</td>
-    <td>{{ form.password }}</td>
-</tr>
-</table>
-
-<input type="submit" value="login" />
-<input type="hidden" name="next" value="{{ next }}" />
+<form method="post" action="{% url 'login' %}" class="form">
+    {% csrf_token %}
+    {% bootstrap_form form %}
+    {% buttons %}
+        <input type="submit" value="login" class="btn btn-primary" />
+    {% endbuttons %}
+    <input type="hidden" name="next" value="{{ next }}" />
 </form>
 
 {% endblock %}

--- a/xorgauth/urls.py
+++ b/xorgauth/urls.py
@@ -18,10 +18,13 @@ from django.contrib import admin
 from django.contrib.auth import views as auth_views
 from django.views.generic import TemplateView
 
+from xorgauth.accounts import views as xorgauth_views
+
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
     url(r'^accounts/login/$', auth_views.LoginView.as_view(), name='login'),
     url(r'^accounts/logout/$', auth_views.LogoutView.as_view(), name='logout'),
+    url(r'^accounts/list_consents/$', xorgauth_views.list_consents, name='list_consents'),
     url(r'^test-relying-party/$', TemplateView.as_view(template_name="test-relying-party.html")),
 ]


### PR DESCRIPTION
This view allows users to list their ongoing consents regarding various clients and the associated authorized scopes, and to selectively revoke them.

Nothing fancy looking, but the logic is here.

The first commit is a hack around the fact that django-oidc-provider expects the user struct to have an email field, not sure if this can be fixed upstream as the function it should be using (`get_email_field_name`), only exists since django 1.11