### PR TITLE
Fix importaccounts script

### DIFF
--- a/xorgauth/management/commands/importaccounts.py
+++ b/xorgauth/management/commands/importaccounts.py
@@ -31,9 +31,10 @@ class Command(BaseCommand):
             user.preferred_name = account_data['display_name']
             user.main_email = account_data['email']
             user.password = hasher.encode_sha1_hash(account_data['password'])
+            user.save()
             if account_data['is_admin']:
                 user.roles.add(admin_role)
-            user.save()
+                user.save()
 
             # Import groups
             for groupname, perms in account_data['groups'].items():


### PR DESCRIPTION
Setting a role on an user cannot be done before this user exists in the
DB (as it does not yet have an id). So save the user before applying its
role.