### PR TITLE
add a scope for X groups

### DIFF
--- a/xorgauth/accounts/oidc_provider_settings.py
+++ b/xorgauth/accounts/oidc_provider_settings.py
@@ -2,6 +2,9 @@
 # Copyright (c) Polytechnique.org
 # This code is distributed under the Affero General Public License version 3
 
+from django.utils.translation import ugettext_lazy as _
+from oidc_provider.lib.claims import ScopeClaims
+
 
 def userinfo(claims, user):
     """Populate claims dict for the given user
@@ -11,3 +14,17 @@ def userinfo(claims, user):
     claims['name'] = user.fullname
     claims['email'] = user.main_email
     return claims
+
+
+class XorgScopeClaims(ScopeClaims):
+    info_xorg_groups = (
+        _("X Groups"),
+        _("The list of the X Groups you belong to")
+    )
+
+    def scope_xorg_groups(self):
+        groups = [membership.group for membership in self.user.groups.all()]
+        dic = {
+            'x_groups': [g.shortname for g in groups]
+        }
+        return dic

--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -135,3 +135,4 @@ STATIC_URL = '/static/'
 
 # django-oidc-provider configuration
 OIDC_USERINFO = 'xorgauth.accounts.oidc_provider_settings.userinfo'
+OIDC_EXTRA_SCOPE_CLAIMS = 'xorgauth.accounts.oidc_provider_settings.XorgScopeClaims'

--- a/xorgauth/templates/test-relying-party.html
+++ b/xorgauth/templates/test-relying-party.html
@@ -56,7 +56,7 @@ c.save()
         // Make an authorization request if the user click the login button.
         $('#login-button').click(function (event) {
             OIDC.login({
-                scope : 'openid profile email',
+                scope : 'openid profile email xorg_groups',
                 response_type : 'id_token token'
             });
         });


### PR DESCRIPTION
This adds simple support for retrieving the list of X groups an user is part of.

This is done by adding a new OIDC scope protecting this information, and populating it with the list of groups if the user allowed it.