### PR TITLE
Allow hrid and email aliases to authenticate

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,25 @@
+from django.test import Client, TestCase
+
+from xorgauth.accounts.models import User, UserAlias
+
+
+class AuthenticationTests(TestCase):
+    def setUp(cls):
+        vaneau = User.objects.create_user(
+            hrid='louis.vaneau.1829',
+            main_email='louis.vaneau.1829@polytechnique.org',
+            password='Depuis Vaneau!'
+        )
+        UserAlias(user=vaneau, email='vaneau@melix.net').save()
+
+    def test_auth_hrid(self):
+        c = Client()
+        self.assertTrue(c.login(username='louis.vaneau.1829', password='Depuis Vaneau!'))
+
+    def test_auth_main_email(self):
+        c = Client()
+        self.assertTrue(c.login(username='louis.vaneau.1829@polytechnique.org', password='Depuis Vaneau!'))
+
+    def test_auth_email_alias(self):
+        c = Client()
+        self.assertTrue(c.login(username='vaneau@melix.net', password='Depuis Vaneau!'))

--- a/xorgauth/accounts/authentication.py
+++ b/xorgauth/accounts/authentication.py
@@ -1,0 +1,32 @@
+from django.contrib.auth.backends import ModelBackend
+
+from xorgauth.accounts.models import User, UserAlias
+
+
+class XorgBackend(ModelBackend):
+    """This backend handles authentication via any mail alias
+
+    It inherits from django's default backend to keep all other behavior,
+    just overriding the user search given an hrid or email
+    """
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        if '@' not in username:
+            # try to login with hrid
+            try:
+                user = User.objects.get(hrid=username)
+            except User.DoesNotExist:
+                return None
+        else:
+            # try to login with email
+            try:
+                # try main email
+                user = User.objects.get(main_email=username)
+            except User.DoesNotExist:
+                # try aliases
+                try:
+                    user = UserAlias.objects.get(email=username).user
+                except UserAlias.DoesNotExist:
+                    return None
+        # we now have a candidate user
+        if user.check_password(password) and self.user_can_authenticate(user):
+            return user

--- a/xorgauth/accounts/models.py
+++ b/xorgauth/accounts/models.py
@@ -33,6 +33,12 @@ class Role(models.Model):
 
 
 class UserManager(base_user.BaseUserManager):
+    def create_user(self, hrid, main_email, password, **extra_fields):
+        main_email = self.normalize_email(main_email)
+        user = self.model(hrid=hrid, main_email=main_email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
 
     def create_superuser(self, hrid, main_email, password, **extra_fields):
         main_email = self.normalize_email(main_email)

--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -44,6 +44,10 @@ INSTALLED_APPS = [
     'bootstrap4',
 ]
 
+AUTHENTICATION_BACKENDS = [
+    'xorgauth.accounts.authentication.XorgBackend'
+]
+
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
This uses a custom authentication backend with the following behavior:

- if the entered value does not contained an `@`, it attempts to log the user in using its hrid
- if it contains an `@`, it first attempts find the user with its `main_email`, and on failure tries to find the user using an email alias

fixes #6 