### PR TITLE
Add a logout button in the navbar and improve the login/logout flow

### DIFF
--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -32,13 +32,13 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     'xorgauth.accounts.apps.AccountsConfig',
+    'xorgauth',
     'django.contrib.admin',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.auth',
-    'xorgauth',
     'oidc_provider',
     'bootstrap4',
 ]

--- a/xorgauth/templates/base.html
+++ b/xorgauth/templates/base.html
@@ -18,6 +18,13 @@
     <nav class="navbar navbar-fixed-top navbar-light bg-faded">
         <div class="container">
             <a class="navbar-brand m-b-0">{% trans 'Polytechnique.org' %}</a>
+            {% block login-nav-button %}
+            {% if user.is_authenticated %}
+                <p class="navbar-right">{{ user.fullname }} <a href="{% url 'logout' %}">{% trans 'Log out' %}</a></p>
+            {% else %}
+                <a class="navbar-button navbar-right" href="{% url 'login' %}">{% trans 'Log in' %}</a>
+            {% endif %}
+            {% endblock %}
         </div>
     </nav>
 

--- a/xorgauth/templates/registration/logged_out.html
+++ b/xorgauth/templates/registration/logged_out.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% load bootstrap4 i18n %}
+
+{% block content %}
+
+<p>{% trans "Thanks for spending some quality time with the Web site today." %}</p>
+
+<p><a href="{% url 'login' %}">{% trans 'Log in again' %}</a></p>
+
+{% endblock %}

--- a/xorgauth/templates/registration/login.html
+++ b/xorgauth/templates/registration/login.html
@@ -1,13 +1,14 @@
 {% extends "base.html" %}
-{% load bootstrap4 %}
+{% load bootstrap4 i18n %}
 
+{% block login-nav-button %}{% endblock %}
 {% block content %}
 
 <form method="post" action="{% url 'login' %}" class="form">
     {% csrf_token %}
     {% bootstrap_form form %}
     {% buttons %}
-        <input type="submit" value="login" class="btn btn-primary" />
+        <input type="submit" value="{% trans 'Log in' %}" class="btn btn-primary" />
     {% endbuttons %}
     <input type="hidden" name="next" value="{{ next }}" />
 </form>


### PR DESCRIPTION
Add a logout button to the navbar. In order for this to work, template
registration/logged_out.html needs to be added to override the one
provided by Django's admin. In order for this overriding to work,
'xorgauth' needs to come before 'django.contrib.admin' in
INSTALLED_APPS.

While at it, translate the login button text.