### PR TITLE
test accessing login-required views

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,67 @@
+import contextlib
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from xorgauth.accounts.models import User
+from xorgauth.urls import urlpatterns as xorgauth_urlpatterns
+
+
+class ViewTests(TestCase):
+    # Views which are publicy accessible
+    PUBLIC_VIEW_IDS = (
+        'login',
+        'logout',
+        'test-relying-party',
+    )
+    # Views which need an authenticated user
+    LOGIN_REQUIRED_VIEW_IDS = (
+        'list_consents',
+        'password_change',
+        'password_change_done',
+        'profile',
+    )
+
+    def test_know_all_views(self):
+        """Check that every accessible view is either in PUBLIC_VIEW_IDS or in LOGIN_REQUIRED_VIEW_IDS"""
+        known_views = set()
+        known_views.update(self.PUBLIC_VIEW_IDS)
+        known_views.update(self.LOGIN_REQUIRED_VIEW_IDS)
+        for urlpattern in xorgauth_urlpatterns:
+            with contextlib.suppress(AttributeError):
+                self.assertIn(urlpattern.name, known_views)
+                known_views.remove(urlpattern.name)
+        # Ensure that every view in the local lists exist
+        self.assertEqual(set(), known_views, "stray view IDs in tests")
+
+    def test_public_views(self):
+        """Test accessing publicy-accessible views"""
+        for url_id in self.PUBLIC_VIEW_IDS:
+            c = Client()
+            resp = c.get(reverse(url_id))
+            self.assertEqual(200, resp.status_code)
+
+    def test_login_required_views_forbidden(self):
+        """Test accessing login-required views without being logged in"""
+        c = Client()
+        for url_id in self.LOGIN_REQUIRED_VIEW_IDS:
+            resp = c.get(reverse(url_id))
+            self.assertEqual(302, resp.status_code,
+                             "unexpected HTTP response code for URL %s" % url_id)
+            self.assertTrue(resp['Location'].startswith('/accounts/login/?'),
+                            "unexpected Location header: %r" % resp['Location'])
+
+    def test_login_required_views_success(self):
+        """Test accessing login-required views while being logged in"""
+        # Create a dummy user
+        User.objects.create_user(
+            hrid='louis.vaneau.1829',
+            main_email='louis.vaneau.1829@polytechnique.org',
+            password='Depuis Vaneau!',
+        )
+        for url_id in self.LOGIN_REQUIRED_VIEW_IDS:
+            c = Client()
+            self.assertTrue(c.login(username='louis.vaneau.1829', password='Depuis Vaneau!'))
+            resp = c.get(reverse(url_id))
+            self.assertEqual(200, resp.status_code,
+                             "unexpected HTTP response code for URL %s" % url_id)

--- a/xorgauth/accounts/views.py
+++ b/xorgauth/accounts/views.py
@@ -30,5 +30,5 @@ def list_consents(request):
     })
 
 
-class ProfileView(TemplateView, LoginRequiredMixin):
+class ProfileView(LoginRequiredMixin, TemplateView):
     template_name = 'profile.html'

--- a/xorgauth/urls.py
+++ b/xorgauth/urls.py
@@ -29,5 +29,5 @@ urlpatterns = [
     url(r'^accounts/password/change/$', auth_views.password_change, name='password_change'),
     url(r'^accounts/password/change/done/$', auth_views.password_change_done, name='password_change_done'),
     url(r'^accounts/profile/$', xorgauth_views.ProfileView.as_view(), name='profile'),
-    url(r'^test-relying-party/$', rptest_views.RelyingParty.as_view()),
+    url(r'^test-relying-party/$', rptest_views.RelyingParty.as_view(), name='test-relying-party'),
 ]


### PR DESCRIPTION
``LoginRequiredMixin`` needs to come first in the parents of a template-based view for it to be applied. Fix such an issue with ``/accounts/profile/`` and add tests to prevent such an issue from appearing again.