### PR TITLE
Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,12 @@ matrix:
       env: TOXENV=py35-django111
     - python: "3.6"
       env: TOXENV=py36-django111
+    - python: "3.4"
+      env: TOXENV=py34-django20
+    - python: "3.5"
+      env: TOXENV=py35-django20
+    - python: "3.6"
+      env: TOXENV=py36-django20
 
     # Linting
     - python: "3.6"

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
 
     python_requires='>=3.4.2' if sys.version_info >= (3,) else '>=2.7',
     install_requires=[
-        'Django>=1.11' if sys.version_info >= (3,) else 'Django>=1.11,<2.0',
+        'Django>=1.11,<2.1' if sys.version_info >= (3,) else 'Django>=1.11,<2.0',
         'django-oidc-provider>=0.5.3',  # Version 0.5.3 is compatible with Django 2.0
         'django-bootstrap3',
         'django-zxcvbn-password',

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,8 @@ setup(
 
     python_requires='>=3.4.2' if sys.version_info >= (3,) else '>=2.7',
     install_requires=[
-        # TODO: drop "Django<2.0" once django-oidc-provider 0.5.3 is released
-        'Django>=1.11,<2.0' if sys.version_info >= (3,) else 'Django>=1.11,<2.0',
-        'django-oidc-provider',
+        'Django>=1.11' if sys.version_info >= (3,) else 'Django>=1.11,<2.0',
+        'django-oidc-provider>=0.5.3',  # Version 0.5.3 is compatible with Django 2.0
         'django-bootstrap3',
         'django-zxcvbn-password',
         'getconf',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py{27,34,35,36}-django{111}
+    py27-django{111}
+    py{34,35,36}-django{111,20}
     lint
     dev
 
@@ -10,6 +11,7 @@ toxworkdir = {env:TOX_WORKDIR:.tox}
 deps =
     -rrequirements_dev.txt
     django111: Django>=1.11,<1.12
+    django20: Django>=2.0,<2.1
 
 whitelist_externals = make
 commands = make test

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ deps =
     -rrequirements_dev.txt
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
+    # This seems to be required in order to update tox's virtualenvironments
+    django20: django-oidc-provider>=0.5.3
 
 whitelist_externals = make
 commands = make test


### PR DESCRIPTION
Django 2.0 requires a minor update in the models. Add this version to tests in order to catch breaking changes.