### PR TITLE
Add on_delete required argument to ForeignKey

### DIFF
--- a/xorgauth/accounts/models.py
+++ b/xorgauth/accounts/models.py
@@ -107,7 +107,7 @@ class User(base_user.AbstractBaseUser):
 
 class UserAlias(models.Model):
     """Alias login"""
-    user = models.ForeignKey(User, related_name='aliases', verbose_name=_("user"))
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='aliases', verbose_name=_("user"))
     email = models.EmailField(_("email alias"), unique=True)
 
     class Meta:
@@ -136,8 +136,8 @@ class GroupMembership(models.Model):
         ('member', _('member')),
         ('admin', _('administrator')),
     )
-    group = models.ForeignKey(Group, related_name='members', verbose_name=_("group"))
-    user = models.ForeignKey(User, related_name='groups', verbose_name=_("member"))
+    group = models.ForeignKey(Group, on_delete=models.CASCADE, related_name='members', verbose_name=_("group"))
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='groups', verbose_name=_("member"))
     perms = models.SlugField(choices=MEMBERSHIP_PERMS)
 
     class Meta:


### PR DESCRIPTION
Django 2.0, released on 2017-12-02, now requires that ForeignKey() gives on_delete argument, which was CASCADE by default.

This commit fixes issues when running ``TOXENV=dev tox`` because ``make update`` now installs Django 2. It does not activate Django 2.0 tests by default as there are issues with the underlying library, c.f. https://github.com/Polytechnique-org/xorgauth/pull/26.