### PR TITLE
Make the project compatible with Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
 
 matrix:
   include:
+    - python: "2.7"
+      env: TOXENV=py27-django111
     - python: "3.4"
       env: TOXENV=py34-django111
     - python: "3.5"

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(
     packages=find_packages(include=[PACKAGE, '%s.*' % PACKAGE]),
     include_package_data=True,
 
-    python_requires='>=3.4.2',
+    #python_requires='>=3.4.2',
+    python_requires='>=2.7',
     install_requires=[
         'Django>=1.11',
     ],

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -1,6 +1,5 @@
 import json
-import urllib.parse
-
+import sys
 from django.core.management import call_command
 from django.test import Client, TestCase
 from django.urls import reverse
@@ -8,6 +7,14 @@ from django.urls import reverse
 import oidc_provider.models
 
 from xorgauth.accounts.models import User, UserAlias
+
+if sys.version_info >= (3,):
+    import urllib.parse
+else:
+    import urlparse
+
+    class urllib(object):
+        parse = urlparse
 
 
 class AuthenticationTests(TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,3 @@
-import contextlib
-
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -29,9 +27,11 @@ class ViewTests(TestCase):
         known_views.update(self.PUBLIC_VIEW_IDS)
         known_views.update(self.LOGIN_REQUIRED_VIEW_IDS)
         for urlpattern in xorgauth_urlpatterns:
-            with contextlib.suppress(AttributeError):
+            try:
                 self.assertIn(urlpattern.name, known_views)
                 known_views.remove(urlpattern.name)
+            except AttributeError:
+                pass
         # Ensure that every view in the local lists exist
         self.assertEqual(set(), known_views, "stray view IDs in tests")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{34,35,36}-django{111}
+    py{27,34,35,36}-django{111}
     lint
     dev
 

--- a/xorgauth/utils/fields.py
+++ b/xorgauth/utils/fields.py
@@ -19,4 +19,4 @@ class UnboundedCharField(models.TextField):
 
     def formfield(self, **kwargs):
         kwargs['widget'] = None if self.choices else forms.TextInput
-        return super().formfield(**kwargs)
+        return super(UnboundedCharField, self).formfield(**kwargs)


### PR DESCRIPTION
The current host only provides Python 3.2 or Python 2.7. As Django is no longer compatible with Python 3.2, use Python 2.7 until the host is upgraded to a supported version of Python 3 (3.4, 3.5 or 3.6).