### PR TITLE
Define STATIC_ROOT in settings.py

### DIFF
--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -178,6 +178,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # django-oidc-provider configuration
 OIDC_USERINFO = 'xorgauth.accounts.oidc_provider_settings.userinfo'


### PR DESCRIPTION
This configuraton variable was missing and is mandatory when deploying the project in production.