### PR TITLE
[packaging] Merge requirements.txt in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include LICENSE README.rst
-include requirements.txt requirements_dev.txt release.txt
+include requirements_dev.txt release.txt
 
 graft xorgauth
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ poupdate:
 
 update:
 	pip install --upgrade pip setuptools
-	pip install --upgrade -r requirements.txt
 	pip install --upgrade -r requirements_dev.txt
 	pip freeze
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-django-oidc-provider
-django-bootstrap4
-getconf

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,9 @@ setup(
     python_requires='>=2.7',
     install_requires=[
         'Django>=1.11',
+        'django-oidc-provider',
+        'django-bootstrap4',
+        'getconf',
     ],
     setup_requires=[
         'setuptools>=0.8',

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ toxworkdir = {env:TOX_WORKDIR:.tox}
 
 [testenv]
 deps =
-    -rrequirements.txt
     -rrequirements_dev.txt
     django111: Django>=1.11,<1.12
 


### PR DESCRIPTION
The Python packaging infrastructure requires all runtime dependencies to
be declared in the setup.py 'install_requires' section.

We avoid duplicating that list by:
1. Listing all requirements there
2. Adding ``-e .`` at the top of the ``requirements_dev.txt`` file, thus
   instructing pip to install the current package as editable, with all
   its declared runtime dependencies.