### PR TITLE
Use Django 2.0 only when using Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,9 @@ setup(
     packages=find_packages(include=[PACKAGE, '%s.*' % PACKAGE]),
     include_package_data=True,
 
-    #python_requires='>=3.4.2',
-    python_requires='>=2.7',
+    python_requires='>=3.4.2' if sys.version_info >= (3,) else '>=2.7',
     install_requires=[
-        'Django>=1.11',
+        'Django>=1.11' if sys.version_info >= (3,) else 'Django>=1.11,<2.0',
         'django-oidc-provider',
         'django-bootstrap3',
         'django-zxcvbn-password',


### PR DESCRIPTION
Django 2.0 is not compatible with Python 2. Indicate this in Django dependency when running Python 2.

While at it, force using Python >= 3.4.2 when using Python 3, like before commit 51a3e7f78514 ("Make the project compatible with Python 2.7")