### PR TITLE
Add "make" to production updating instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,8 @@ Here are instructions specific to xorgauth application for upgrading::
     make update
     python manage.py migrate
     python manage.py collectstatic
+    # Recompile the translation files
+    make
 
 
 Notes

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ Run the following commands in order to setup a development environment on a loca
 
     make update
     make createdb
+    make
     python manage.py createsuperuser --fullname me --hrid me --preferred_name me --main_email me@localhost.localdomain
     python manage.py importaccounts scripts/dev_data.json
     python manage.py importauthgroupex scripts/dev_data.json

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ commands = make lint
 whitelist_externals = make
 commands =
     make update
+    make
     make createdb
     python manage.py importaccounts scripts/dev_data.json
     python manage.py importauthgroupex scripts/dev_data.json


### PR DESCRIPTION
Running "make" is required in order to compile the django.po files.