### PR TITLE
Use None instead of 0 for unknown school ID

### DIFF
--- a/scripts/export_platal_to_json.py
+++ b/scripts/export_platal_to_json.py
@@ -70,6 +70,8 @@ with db.cursor() as cursor:
     for row in cursor:
         entry = OrderedDict(zip(cols, row))
         uid = int(entry['uid'])
+        if entry['xorg_id'] == 0:
+            entry['xorg_id'] = None
         entry['email_source'] = OrderedDict()
         entry['email_redirect'] = OrderedDict()
         entry['groups'] = OrderedDict()


### PR DESCRIPTION
Some Master accounts has ``xorg_id=0`` instead of ``NULL`` in the MySQL database. This makes it non-unique in the imported data, which breaks ``manage.py importaccounts``.

Fix this by translating 0 to ``NULL``, ie. ``None`` in Python.