### PR TITLE
Make sure Django 1 gets installed instead of Django 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
 
     python_requires='>=3.4.2' if sys.version_info >= (3,) else '>=2.7',
     install_requires=[
-        'Django>=1.11' if sys.version_info >= (3,) else 'Django>=1.11,<2.0',
+        # TODO: drop "Django<2.0" once django-oidc-provider 0.5.3 is released
+        'Django>=1.11,<2.0' if sys.version_info >= (3,) else 'Django>=1.11,<2.0',
         'django-oidc-provider',
         'django-bootstrap3',
         'django-zxcvbn-password',


### PR DESCRIPTION
The last release of django-oidc-provider (0.5.2) was not compatible with Django 2.0. A fix has been integrated upstream (https://github.com/juanifioren/django-oidc-provider/pull/216) but no released version of django-oidc-provider comes with it yet.

Wait for such a release by marking Django 2.0 as unsupported for now in the setup.py requirements, event with Python 3.