### PR TITLE
Update the groups perms when importing data over an existing member

### DIFF
--- a/xorgauth/management/commands/importaccounts.py
+++ b/xorgauth/management/commands/importaccounts.py
@@ -108,10 +108,17 @@ class Command(BaseCommand):
             # Import groups
             for groupname, perms in account_data['groups'].items():
                 group = Group.objects.get_or_create(shortname=groupname)[0]
-                GroupMembership.objects.get_or_create(
+                membership, created = GroupMembership.objects.get_or_create(
                     group=group,
                     user=user,
-                    perms=perms)
+                    defaults={'perms': perms})
+                if not created and membership.perms != perms:
+                    membership.perms = perms
+                    membership.full_clean()
+                    membership.save()
+                else:
+                    # check values, to ensure a sane database
+                    membership.full_clean()
 
             # Import email aliases
             for email in account_data['email_source'].keys():


### PR DESCRIPTION
When importing the accounts data several times into the same database
(in order to keep it roughly in sync with the original database along
the days of beta-testing), group membership permissions can change. Do
not crash the script when this occurs (because (user,group) is unique in
the group membership table), but instead update the permission
accordingly.