### PR TITLE
Hide the link to the user consents if there are none

### DIFF
--- a/xorgauth/accounts/views.py
+++ b/xorgauth/accounts/views.py
@@ -40,6 +40,10 @@ class IndexView(LoginRequiredMixin, RedirectView):
 class ProfileView(LoginRequiredMixin, TemplateView):
     template_name = 'profile.html'
 
+    def user_has_consents(self):
+        """Return true if the logged user has any consent"""
+        return UserConsent.objects.filter(user=self.request.user).exists()
+
 
 class PasswordChangeView(auth_views.PasswordChangeView):
     form_class = PasswordChangeForm

--- a/xorgauth/templates/profile.html
+++ b/xorgauth/templates/profile.html
@@ -10,7 +10,9 @@
         <p>{% trans "Here are some pages you can access while you are logged in:" %}</p>
 
         <ul>
+        {% if view.user_has_consents %}
         <li><a href="{% url 'list_consents' %}">{% trans "List of consents given to web sites" %}</li>
+        {% endif %}
         <li><a href="{% url 'password_change' %}"> {% trans "Change your password" %}</li>
         </ul>
     </div>


### PR DESCRIPTION
This link confuses some users who do not understand what the list of consents is and why it is empty.