### PR TITLE
Add generated dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 
 # Dev-related files
 dev/
+/static/
+/.tox/
 
 # Build-related files
 doc/_build/


### PR DESCRIPTION
A ``static`` directory is created by ``manage.py collectstatic`` and a ``.tox`` is created by running tox. These directories should never be committed.