### PR TITLE
Improve some wordings

### DIFF
--- a/xorgauth/forms.py
+++ b/xorgauth/forms.py
@@ -6,6 +6,14 @@ from zxcvbn_password.fields import PasswordField, PasswordConfirmationField
 from xorgauth.accounts.models import User
 
 
+class AuthenticationForm(auth_forms.AuthenticationForm):
+    # override username label
+    username = auth_forms.UsernameField(
+        label=_("User name or email address"),
+        widget=django.forms.TextInput(attrs={'placeholder': _('firstname.lastname.gradyear')}),
+        max_length=254)
+
+
 class SetPasswordForm(auth_forms.SetPasswordForm):
     new_password1 = PasswordField(
         label=_("New password"),

--- a/xorgauth/locale/fr/LC_MESSAGES/django.po
+++ b/xorgauth/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xorgauth 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-14 23:48+0100\n"
+"POT-Creation-Date: 2018-02-15 15:31+0100\n"
 "PO-Revision-Date: 2017-12-03 22:42+0100\n"
 "Last-Translator: Nicolas Iooss\n"
 "Language: \n"
@@ -344,6 +344,10 @@ msgstr ""
 #: xorgauth/templates/base.html:39
 msgid "Log out"
 msgstr "Déconnexion"
+
+#: xorgauth/templates/list_consents.html:27
+msgid "Revoke"
+msgstr "Révoquer"
 
 #: xorgauth/templates/oidc_provider/authorize.html:8
 msgid "Request for Permission"

--- a/xorgauth/locale/fr/LC_MESSAGES/django.po
+++ b/xorgauth/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: xorgauth 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-02-15 15:31+0100\n"
+"POT-Creation-Date: 2018-02-15 15:57+0100\n"
 "PO-Revision-Date: 2017-12-03 22:42+0100\n"
 "Last-Translator: Nicolas Iooss\n"
 "Language: \n"
@@ -285,23 +285,23 @@ msgstr ""
 msgid "Log in"
 msgstr "Connexion"
 
-#: xorgauth/forms.py:11
-msgid "New password"
-msgstr "Nouveau mot de passe"
-
-#: xorgauth/forms.py:16
-msgid "New password confirmation"
-msgstr "Confirmation du nouveau mot de passe"
-
-#: xorgauth/forms.py:30
+#: xorgauth/forms.py:12 xorgauth/forms.py:37
 msgid "User name or email address"
 msgstr "Nom d'utilisateur ou couriel"
 
-#: xorgauth/forms.py:31
+#: xorgauth/forms.py:13 xorgauth/forms.py:38
 msgid "firstname.lastname.gradyear"
 msgstr "prenom.nom.promo"
 
-#: xorgauth/forms.py:40
+#: xorgauth/forms.py:18
+msgid "New password"
+msgstr "Nouveau mot de passe"
+
+#: xorgauth/forms.py:23
+msgid "New password confirmation"
+msgstr "Confirmation du nouveau mot de passe"
+
+#: xorgauth/forms.py:47
 msgid "Unknown user account"
 msgstr "Compte utilisateur inconnu"
 

--- a/xorgauth/templates/list_consents.html
+++ b/xorgauth/templates/list_consents.html
@@ -24,7 +24,7 @@
             <form action="{{ request.path }}" method="POST">
                 {% csrf_token %}
                 <input type="hidden" name="revoke" value="{{ consent.client.client_id }}" />
-                <input type="submit" value="Revoke" class="btn btn-secondary" />
+                <input type="submit" value="{% trans "Revoke" %}" class="btn btn-secondary" />
             </form>
         </td>
     </tr>

--- a/xorgauth/urls.py
+++ b/xorgauth/urls.py
@@ -20,12 +20,15 @@ from django.contrib.auth import views as auth_views
 from xorgauth.accounts import views as xorgauth_views
 from xorgauth.authgroupex import views as authgpx_views
 from xorgauth.relying_party_test import views as rptest_views
+from xorgauth import forms as xorgauth_forms
 
 urlpatterns = [
     url(r'^$', xorgauth_views.IndexView.as_view(), name='index'),
     url(r'^admin/', admin.site.urls),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
-    url(r'^accounts/login/$', auth_views.LoginView.as_view(), name='login'),
+    url(r'^accounts/login/$',
+        auth_views.LoginView.as_view(authentication_form=xorgauth_forms.AuthenticationForm),
+        name='login'),
     url(r'^accounts/logout/$', auth_views.LogoutView.as_view(), name='logout'),
     url(r'^accounts/list_consents/$', xorgauth_views.list_consents, name='list_consents'),
     url(r'^accounts/password/change/$', xorgauth_views.PasswordChangeView.as_view(), name='password_change'),


### PR DESCRIPTION
- Translate "Revoke" in the authorization list
- clarify that the login form accepts both email and forlife