### PR TITLE
Show "prenom.nom.promo" as the login placeholder in autgroupex login form

### DIFF
--- a/xorgauth/authgroupex/views.py
+++ b/xorgauth/authgroupex/views.py
@@ -12,11 +12,14 @@ from django.urls import reverse
 from django.utils import timezone
 from django.views.generic import View
 
+from xorgauth import forms as xorgauth_forms
+
 from .models import AuthGroupeXClient
 
 
 class AuthGroupeXLoginView(auth_views.LoginView):
     template_name = 'authgroupex/login.html'
+    authentication_form = xorgauth_forms.AuthenticationForm
 
     def get_context_data(self, **kwargs):
         context = super(AuthGroupeXLoginView, self).get_context_data(**kwargs)


### PR DESCRIPTION
Otherwise some users might try to log in with their full names.