### PR TITLE
Do not use email field if it is empty

### DIFF
--- a/xorgauth/accounts/views.py
+++ b/xorgauth/accounts/views.py
@@ -7,7 +7,7 @@ from django.views.generic.base import RedirectView, TemplateView
 
 from oidc_provider.models import UserConsent, Client
 
-from xorgauth.forms import PasswordChangeForm, PasswordResetFrom, SetPasswordForm
+from xorgauth.forms import PasswordChangeForm, PasswordResetForm, SetPasswordForm
 
 
 @login_required
@@ -55,7 +55,7 @@ class PasswordChangeView(auth_views.PasswordChangeView):
 
 
 class PasswordResetView(auth_views.PasswordResetView):
-    form_class = PasswordResetFrom
+    form_class = PasswordResetForm
 
 
 class PasswordResetConfirmView(auth_views.PasswordResetConfirmView):

--- a/xorgauth/forms.py
+++ b/xorgauth/forms.py
@@ -43,7 +43,7 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
         cleaned_data = super(PasswordResetForm, self).clean()
         # Transform a login or an email alias to a main email address
         if 'email' not in cleaned_data:
-            return
+            return cleaned_data
         email = cleaned_data['email']
         user = User.objects.get_for_login(email, True)
         if user is None:

--- a/xorgauth/forms.py
+++ b/xorgauth/forms.py
@@ -30,7 +30,7 @@ class PasswordChangeForm(SetPasswordForm, auth_forms.PasswordChangeForm):
     pass
 
 
-class PasswordResetFrom(auth_forms.PasswordResetForm):
+class PasswordResetForm(auth_forms.PasswordResetForm):
     """Override PasswordResetForm from django.contrib.auth in order to allow
     any user alias when recovering a lost password
     """
@@ -40,7 +40,7 @@ class PasswordResetFrom(auth_forms.PasswordResetForm):
         max_length=254)
 
     def clean(self):
-        cleaned_data = super(PasswordResetFrom, self).clean()
+        cleaned_data = super(PasswordResetForm, self).clean()
         # Transform a login or an email alias to a main email address
         if 'email' not in cleaned_data:
             return

--- a/xorgauth/forms.py
+++ b/xorgauth/forms.py
@@ -53,6 +53,7 @@ class PasswordResetForm(auth_forms.PasswordResetForm):
 
         cleaned_data['user'] = user
         cleaned_data['email'] = user.main_email
+        return cleaned_data
 
     def get_users(self, email):
         # get_users is only called when self.cleaned_data has been populated,

--- a/xorgauth/forms.py
+++ b/xorgauth/forms.py
@@ -42,6 +42,8 @@ class PasswordResetFrom(auth_forms.PasswordResetForm):
     def clean(self):
         cleaned_data = super(PasswordResetFrom, self).clean()
         # Transform a login or an email alias to a main email address
+        if 'email' not in cleaned_data:
+            return
         email = cleaned_data['email']
         user = User.objects.get_for_login(email, True)
         if user is None:


### PR DESCRIPTION
When the email address (or username) entered into the password reset
form is empty, "cleaned_data = super(PasswordResetFrom, self).clean()"
drop this field, but PasswordResetFrom.clean() expects
cleaned_data['email'] to be present. Remove such an assumption.

It is currently easy to trigger an HTTP 500 error by entering a space in
the recovery email form field.