### PR TITLE
Add error emails configuration

### DIFF
--- a/example_settings.ini
+++ b/example_settings.ini
@@ -47,5 +47,9 @@ user = xorgauth
 password = ******
 ; Whether to use TLS to communicate with the SMTP server
 tls = true
-; The email address by default from who receive the message
+; The default email address to use for various automated correspondence (e.g. for password recovery)
 default_from_email = Polytechnique.org <noreply@polytechnique.org>
+; The email address that error messages come from, such as those sent to ADMINS and MANAGERS.
+server_email = Polytechnique.org <noreply@polytechnique.org>
+; Subjet prefix for emails sent to the administrators
+subject_prefix = [Django xorgauth]

--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -221,6 +221,8 @@ EMAIL_HOST_USER = config.getstr("email.user")
 EMAIL_HOST_PASSWORD = config.getstr("email.password")
 EMAIL_USE_TLS = config.getbool("email.tls")
 DEFAULT_FROM_EMAIL = config.getstr("email.default_from_email", "Polytechnique.org <noreply@polytechnique.org>")
+SERVER_EMAIL = config.getstr("email.server_email", "Polytechnique.org <noreply@polytechnique.org>")
+EMAIL_SUBJECT_PREFIX = config.getstr('email.subject_prefix', '[Django xorgauth]') + ' '
 
 # In development mode, send messages to the console
 if APPMODE == 'dev':


### PR DESCRIPTION
Emails generated by internal errors were sent from root@localhost with
"[Django] " prefix. Allow customization in the config file so that the
error emails can be more specific to xorgauth.