### PR TITLE
Add security settings in conf

### DIFF
--- a/example_settings.ini
+++ b/example_settings.ini
@@ -53,3 +53,9 @@ default_from_email = Polytechnique.org <noreply@polytechnique.org>
 server_email = Polytechnique.org <noreply@polytechnique.org>
 ; Subjet prefix for emails sent to the administrators
 subject_prefix = [Django xorgauth]
+
+[security]
+; SSL settings
+
+; Whether to use SSL
+use_ssl = false

--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -227,3 +227,9 @@ EMAIL_SUBJECT_PREFIX = config.getstr('email.subject_prefix', '[Django xorgauth]'
 # In development mode, send messages to the console
 if APPMODE == 'dev':
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
+# Security
+USE_HTTPS = (APPMODE == 'prod') or config.getbool("security.use_ssl")
+SECURE_SSL_REDIRECT = USE_HTTPS
+SESSION_COOKIE_SECURE = USE_HTTPS
+CSRF_COOKIE_SECURE = USE_HTTPS


### PR DESCRIPTION
Issue #93 
- Add settings `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE` and `SECURE_SSL_REDIRECT` in `settings.py`.
- Add these settings in `eample_settings.ini` (for getconf)