### PR TITLE
Enable secure settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ matrix:
     # Test dev makefile
     - python: "3.6"
       env: TOXENV=dev
+    # Check default production settings
+    - python: "3.6"
+      env: TOXENV=prodsettings
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ testall:
 test: build
 	PYTHONPATH=. python -Wdefault manage.py test $(TESTS_DIR)
 
+checkdeploy:
+	python manage.py check --deploy --fail-level WARNING
 
 
 lint:
@@ -67,4 +69,4 @@ doc:
 	$(MAKE) -C $(DOC_DIR) html
 
 
-.PHONY: all default clean coverage createdb doc install-deps lint update poupdate test testall
+.PHONY: all checkdeploy clean coverage createdb default doc install-deps lint poupdate test testall update

--- a/example_settings.ini
+++ b/example_settings.ini
@@ -59,3 +59,6 @@ subject_prefix = [Django xorgauth]
 
 ; Whether to use SSL
 use_ssl = false
+; HTTP Strict Transport Security header "max-age" duration, in seconds
+; https://infosec.mozilla.org/guidelines/web_security#http-strict-transport-security
+hsts_seconds = 15768000

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{27,34,35,36}-django{111}
     lint
     dev
+    prodsettings
 
 toxworkdir = {env:TOX_WORKDIR:.tox}
 
@@ -29,3 +30,12 @@ commands =
     make createdb
     python manage.py importaccounts scripts/dev_data.json
     python manage.py importauthgroupex scripts/dev_data.json
+
+[testenv:prodsettings]
+whitelist_externals = make
+setenv =
+    XORGAUTH_APP_MODE = prod
+    XORGAUTH_APP_SECRET_KEY = this is a long key to pass SECRET_KEY length check
+    XORGAUTH_SITE_ALLOWED_HOSTS = 127.0.0.1,::1,localhost
+commands =
+    make checkdeploy

--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -229,7 +229,17 @@ if APPMODE == 'dev':
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # Security
+SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_BROWSER_XSS_FILTER = True
+X_FRAME_OPTIONS = 'DENY'
+
 USE_HTTPS = (APPMODE == 'prod') or config.getbool("security.use_ssl")
 SECURE_SSL_REDIRECT = USE_HTTPS
 SESSION_COOKIE_SECURE = USE_HTTPS
 CSRF_COOKIE_SECURE = USE_HTTPS
+
+if USE_HTTPS:
+    # Force using HSTS with HTTPS
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+    SECURE_HSTS_PRELOAD = True
+    SECURE_HSTS_SECONDS = config.getint('security.hsts_seconds', 15768000)


### PR DESCRIPTION
"manage.py check --deploy" reported a bunch of warnings about disabled security headers, and https://observatory.mozilla.org/analyze/auth.polytechnique.org reports a "F" grade.

Improve the security aspect by enabled some headers, following Django's and Mozilla Observatory's advices:
- the website should never be used in an iframe
- the website should always be used over HTTPS in production

Also check the default production settings with tox and Travis-CI.