### PR TITLE
Add page header with the title of the page

### DIFF
--- a/xorgauth/templates/list_consents.html
+++ b/xorgauth/templates/list_consents.html
@@ -5,6 +5,8 @@
 
 {% bootstrap_messages %}
 
+<h2>{% trans "List of consents given to web sites" %}</h2>
+
 <table class="table table-striped">
     <thead>
         <tr>

--- a/xorgauth/templates/registration/password_change_form.html
+++ b/xorgauth/templates/registration/password_change_form.html
@@ -1,7 +1,11 @@
 {% extends 'base.html' %}
 {% load i18n static bootstrap3 %}
 
-{% block content %}<div id="content-main">
+{% block content %}
+
+<h2>{% trans "Change your password" %}</h2>
+
+<div id="content-main">
 
 <form method="post" class="form">
     {% csrf_token %}


### PR DESCRIPTION
When a user comes to the password change page, nothing said that it was
the password change page. Add a HTML header to fix this, and do so to
the consent list page too.

As the titles match the links of the profile page, they are already
translated.