### PR TITLE
Introduce a maintenance ("read-only") mode

### DIFF
--- a/example_settings.ini
+++ b/example_settings.ini
@@ -7,6 +7,9 @@ mode = prod
 debug = off
 ; A local, secret string for cryptographical signatures
 secret_key = ********
+; Server maintenance mode: do not allow updating user data while still allowing
+; users to use the application
+maintenance = off
 
 
 [site]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,4 @@
-from django.test import Client, TestCase
+from django.test import Client, TestCase, override_settings
 from django.urls import reverse
 
 from xorgauth.accounts.models import User
@@ -88,3 +88,18 @@ class ViewTests(TestCase):
             else:
                 self.assertEqual(200, resp.status_code,
                                  "unexpected HTTP response code for URL %s" % url_id)
+
+    @override_settings(MAINTENANCE=True)
+    def test_public_views_maintenance(self):
+        """Test accessing publicy-accessible views in maintenance mode"""
+        self.test_public_views()
+
+    @override_settings(MAINTENANCE=True)
+    def test_login_required_views_forbidden_maintenance(self):
+        """Test accessing login-required views without being logged in, in maintenance mode"""
+        self.test_login_required_views_forbidden()
+
+    @override_settings(MAINTENANCE=True)
+    def test_login_required_views_success_maintenance(self):
+        """Test accessing accessing login-required views while being logged in, in maintenance mode"""
+        self.test_login_required_views_success()

--- a/xorgauth/accounts/views.py
+++ b/xorgauth/accounts/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import views as auth_views
 from django.contrib.auth.decorators import login_required
@@ -50,13 +51,25 @@ class ProfileView(LoginRequiredMixin, TemplateView):
         return user.main_email if user.is_x_alumni() else None
 
 
-class PasswordChangeView(auth_views.PasswordChangeView):
-    form_class = PasswordChangeForm
+if settings.MAINTENANCE:
+    # Disable the forms in maintenance mode
 
+    class PasswordChangeView(LoginRequiredMixin, TemplateView):
+        template_name = 'registration/password_cefeffehange_form.html'
 
-class PasswordResetView(auth_views.PasswordResetView):
-    form_class = PasswordResetForm
+    class PasswordResetView(TemplateView):
+        template_name = 'registration/password_reset_form.html'
 
+    class PasswordResetConfirmView(TemplateView):
+        template_name = 'registration/password_reset_confirm.html'
 
-class PasswordResetConfirmView(auth_views.PasswordResetConfirmView):
-    form_class = SetPasswordForm
+else:
+
+    class PasswordChangeView(auth_views.PasswordChangeView):
+        form_class = PasswordChangeForm
+
+    class PasswordResetView(auth_views.PasswordResetView):
+        form_class = PasswordResetForm
+
+    class PasswordResetConfirmView(auth_views.PasswordResetConfirmView):
+        form_class = SetPasswordForm

--- a/xorgauth/context_processors.py
+++ b/xorgauth/context_processors.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+def maintenance(request):
+    """Export settings.MAINTENANCE to templates"""
+    return {
+        'MAINTENANCE': settings.MAINTENANCE,
+    }

--- a/xorgauth/locale/fr/LC_MESSAGES/django.po
+++ b/xorgauth/locale/fr/LC_MESSAGES/django.po
@@ -382,6 +382,17 @@ msgstr ""
 msgid "Log out"
 msgstr "Déconnexion"
 
+#: xorgauth/templates/base.html:51
+msgid ""
+"<strong>Warning!</strong> Due to a maintenance operation, some features on "
+"this website are currently disabled. No data will be saved and the password "
+"change page is temporarily disabled."
+msgstr ""
+"<strong>Attention&nbsp;!</strong> En raison d'une maintenance, une partie "
+"des fonctionnalités du site est actuellement désactivée, en particulier "
+"aucune donnée ne sera sauvegardée et la page de modification de mot de passe "
+"est temporairement désactivée."
+
 #: xorgauth/templates/list_consents.html:8 xorgauth/templates/profile.html:14
 msgid "List of consents given to web sites"
 msgstr "Liste des autorisations données aux sites web"
@@ -457,7 +468,17 @@ msgstr "Mot de passe oublié ?"
 msgid "Your password was changed."
 msgstr "Votre mot de passe a été modifié."
 
-#: xorgauth/templates/registration/password_change_form.html:13
+#: xorgauth/templates/registration/password_change_form.html:9
+#: xorgauth/templates/registration/password_reset_confirm.html:6
+#: xorgauth/templates/registration/password_reset_form.html:7
+msgid ""
+"Due to a maintenance operation, this page is temporarily disabled. Sorry for "
+"the inconvenience."
+msgstr ""
+"En raison d'une maintenance, cette page est temporairement désactivée. "
+"Veuillez nous excuser pour la gêne occasionée."
+
+#: xorgauth/templates/registration/password_change_form.html:15
 msgid ""
 "Please enter your old password, for security's sake, and then enter your new "
 "password twice so we can verify you typed it in correctly."
@@ -466,8 +487,8 @@ msgstr ""
 "nouveau mot de passe à deux reprises afin de vérifier qu'il est correctement "
 "saisi."
 
-#: xorgauth/templates/registration/password_change_form.html:17
-#: xorgauth/templates/registration/password_reset_form.html:8
+#: xorgauth/templates/registration/password_change_form.html:19
+#: xorgauth/templates/registration/password_reset_form.html:12
 msgid "Submit"
 msgstr "Soumettre"
 
@@ -480,12 +501,12 @@ msgstr ""
 "Votre mot de passe a été défini. Vous pouvez maintenant <a href="
 "\"%(login_url)s\">vous connecter</a>."
 
-#: xorgauth/templates/registration/password_reset_confirm.html:6
-#: xorgauth/templates/registration/password_reset_confirm.html:10
+#: xorgauth/templates/registration/password_reset_confirm.html:9
+#: xorgauth/templates/registration/password_reset_confirm.html:13
 msgid "Change password"
 msgstr "Modifier le mot de passe"
 
-#: xorgauth/templates/registration/password_reset_confirm.html:24
+#: xorgauth/templates/registration/password_reset_confirm.html:27
 msgid ""
 "The password reset link was invalid, possibly because it has already been "
 "used. Please request a new password reset."

--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -28,6 +28,8 @@ config = getconf.ConfigGetter('xorgauth', [
 APPMODE = config.getstr('app.mode', 'dev')
 assert APPMODE in ('dev', 'dist', 'prod'), "Invalid application mode %s" % APPMODE
 
+MAINTENANCE = config.getbool('app.maintenance', False)
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
@@ -90,6 +92,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'xorgauth.context_processors.maintenance',
             ],
         },
     },

--- a/xorgauth/templates/base.html
+++ b/xorgauth/templates/base.html
@@ -45,6 +45,12 @@
     </nav>
 
     <div class="container" style="margin-top: 10em;">
+    {% if MAINTENANCE %}
+        <div class="alert alert-warning">
+            <a href="#" class="close" data-dismiss="alert">&times;</a>
+            {% trans '<strong>Warning!</strong> Due to a maintenance operation, some features on this website are currently disabled. No data will be saved and the password change page is temporarily disabled.' %}
+        </div>
+    {% endif %}
     {% block content %}{% endblock %}
     </div>
 

--- a/xorgauth/templates/registration/password_change_form.html
+++ b/xorgauth/templates/registration/password_change_form.html
@@ -5,6 +5,10 @@
 
 <h2>{% trans "Change your password" %}</h2>
 
+{% if MAINTENANCE %}
+<p>{% trans "Due to a maintenance operation, this page is temporarily disabled. Sorry for the inconvenience." %}</p>
+{% else %}
+
 <form method="post" class="form">
     {% csrf_token %}
 
@@ -26,5 +30,7 @@
     {{ form.media }}
 
 </form>
+
+{% endif %}
 
 {% endblock %}

--- a/xorgauth/templates/registration/password_change_form.html
+++ b/xorgauth/templates/registration/password_change_form.html
@@ -5,8 +5,6 @@
 
 <h2>{% trans "Change your password" %}</h2>
 
-<div id="content-main">
-
 <form method="post" class="form">
     {% csrf_token %}
 

--- a/xorgauth/templates/registration/password_reset_confirm.html
+++ b/xorgauth/templates/registration/password_reset_confirm.html
@@ -2,6 +2,9 @@
 {% load i18n bootstrap3 %}
 
 {% block content %}
+{% if MAINTENANCE %}
+<p>{% trans "Due to a maintenance operation, this page is temporarily disabled. Sorry for the inconvenience." %}</p>
+{% else %}
   {% if validlink %}
     <h3>{% trans "Change password" %}</h3>
     <form method="post">
@@ -24,4 +27,5 @@
       {% trans "The password reset link was invalid, possibly because it has already been used. Please request a new password reset." %}
     </p>
   {% endif %}
+{% endif %}
 {% endblock %}

--- a/xorgauth/templates/registration/password_reset_form.html
+++ b/xorgauth/templates/registration/password_reset_form.html
@@ -1,10 +1,15 @@
 {% extends 'base.html' %}
 {% load i18n bootstrap3 %}
 {% block content %}
-  <h3>{% trans "Reset password?" %}</h3>
-  <form method="post">
-    {% csrf_token %}
-    {% bootstrap_form form %}
-    <button type="submit" class="btn btn-primary">{% trans "Submit" %}</button>
-  </form>
+<h3>{% trans "Reset password?" %}</h3>
+
+{% if MAINTENANCE %}
+<p>{% trans "Due to a maintenance operation, this page is temporarily disabled. Sorry for the inconvenience." %}</p>
+{% else %}
+<form method="post">
+  {% csrf_token %}
+  {% bootstrap_form form %}
+  <button type="submit" class="btn btn-primary">{% trans "Submit" %}</button>
+</form>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
When performing maintenance operations, it is useful to have a way of forbidding to modify data in the database, while still allowing users to log in on third-party websites.

This is still a work in progress: there is a message which is displayed on pages, which disable forms, but the backend remains reachable and active.