### PR TITLE
Add the password reset button on the authgroupex login page

### DIFF
--- a/xorgauth/authgroupex/templates/authgroupex/login.html
+++ b/xorgauth/authgroupex/templates/authgroupex/login.html
@@ -13,5 +13,6 @@
     {% endbuttons %}
     <input type="hidden" name="next" value="{{ next }}" />
 </form>
+<a href="{% url 'password_reset' %}" class="btn btn-primary">{% trans 'Forgotten password?' %}</a>
 
 {% endblock %}


### PR DESCRIPTION
The button to reset the password was not present when using authgroupex, for example when connecting to www.polytechnique.org or www.polytechnique.net...