### PR TITLE
Fix Plat/al export script after last upgrade

### DIFF
--- a/scripts/export_platal_to_json.py
+++ b/scripts/export_platal_to_json.py
@@ -71,7 +71,7 @@ with db.cursor() as cursor:
     for row in cursor:
         entry = OrderedDict(zip(cols, row))
         uid = int(entry['uid'])
-        if entry['xorg_id'] == 0:
+        if entry['xorg_id'] in ('0', ''):
             entry['xorg_id'] = None
         if entry['ax_id'] == '':
             entry['ax_id'] = None


### PR DESCRIPTION
Since https://github.com/Polytechnique-org/platal/commit/31933fafc2e7ed546f48fe2fafe360b5daf74662 the field `profiles.xorg_id` is a `VARCHAR` instead of an `INT` in the database. So testing `"== 0"` no longer works, which makes importing Plat/al data fail:

    django.core.exceptions.ValidationError: {'schoolid': [u'Un objet
    User account avec ce champ School ID existe d\xe9j\xe0.']}

Fix this by comparing with strings.