### PR TITLE
Add "coding: utf-8" to importaccounts.py

### DIFF
--- a/xorgauth/management/commands/importaccounts.py
+++ b/xorgauth/management/commands/importaccounts.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import json
 


### PR DESCRIPTION
This is required to run it with Python 2, since commit 647979b2d511 ("Import account types specific to new cursus") introduced "Master spécialisé" with unicode characters in this file.