### PR TITLE
Use the correct lang in HTML5 tag

### DIFF
--- a/xorgauth/templates/base.html
+++ b/xorgauth/templates/base.html
@@ -1,7 +1,8 @@
 {% load i18n staticfiles bootstrap3 %}
 
 <!DOCTYPE html>
-<html lang="en">
+{% get_current_language as LANGUAGE_CODE %}
+<html lang="{{ LANGUAGE_CODE }}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
Use `<html lang="fr">` when using the website in French and `<html lang="en">` when it is in English.