### PR TITLE
Support django-oidc-provider 0.7.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,10 @@ In such a development environment, in order to use the test relying party:
 
   .. code-block:: python
 
-      from oidc_provider.models import Client
-      c = Client(name='Test RP', client_id='123456', response_type='id_token token', redirect_uris=['http://localhost:8000/test-relying-party/','http://127.0.0.1:8000/test-relying-party/'])
+      from oidc_provider.models import Client, ResponseType
+      c = Client(name='Test RP', client_id='123456', redirect_uris=['http://localhost:8000/test-relying-party/','http://127.0.0.1:8000/test-relying-party/'])
       c.save()
+      c.response_types.add(ResponseType.objects.get(value='id_token token'))
 
 * run ``python manage.py runserver 8000``
 * open http://localhost:8000/test-relying-party/ in a web browser and click on the log in button

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     python_requires='>=3.4.2' if sys.version_info >= (3,) else '>=2.7',
     install_requires=[
         'Django>=1.11,<2.1' if sys.version_info >= (3,) else 'Django>=1.11,<2.0',
-        'django-oidc-provider>=0.5.3',  # Version 0.5.3 is compatible with Django 2.0
+        'django-oidc-provider>=0.7.0',  # Version 0.7.0 has a breaking change in response types
         'django-bootstrap3',
         'django-zxcvbn-password',
         'getconf',

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -26,10 +26,12 @@ class AuthenticationTests(TestCase):
             client_id='123456789',
             client_type='public',
             client_secret='',
-            response_type='id_token token',
             redirect_uris=['http://example.com/'],
             require_consent=False)
         client_public_noconsent.save()
+
+        response_type = oidc_provider.models.ResponseType.objects.get(value='id_token token')
+        client_public_noconsent.response_types.add(response_type)
 
         vaneau = User.objects.create_user(
             hrid='louis.vaneau.1829',


### PR DESCRIPTION
django-oidc-provider 0.7.0 moved OIDC client's response_type field to a
ManyToManyField. Change the test accordingly.

cf. https://github.com/juanifioren/django-oidc-provider/commit/36018d19aee0d065b793c9f8e4e3b824fe24b5dd