### PR TITLE
Test Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: python
 cache: pip
+dist: bionic
 
 branches:
   only:
@@ -28,15 +29,17 @@ matrix:
       env: TOXENV=py35-django20
     - python: "3.6"
       env: TOXENV=py36-django20
+    - python: "3.7"
+      env: TOXENV=py37-django20
 
     # Linting
-    - python: "3.6"
+    - python: "3.7"
       env: TOXENV=lint
     # Test dev makefile
-    - python: "3.6"
+    - python: "3.7"
       env: TOXENV=dev
     # Check default production settings
-    - python: "3.6"
+    - python: "3.7"
       env: TOXENV=prodsettings
 
 notifications:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py27-django{111}
-    py{34,35,36}-django{111,20}
+    py{34,35,36,37}-django{111,20}
     lint
     dev
     prodsettings


### PR DESCRIPTION
This requires specifying the distribution which is used by Travis-CI, as the default one (Ubuntu 14.04 Trusty) does not have Python 3.7.