### PR TITLE
Make sure Django stays below 2.1 when Python 3.4 is used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
 
     python_requires='>=3.4.2' if sys.version_info >= (3,) else '>=2.7',
     install_requires=[
-        'Django>=1.11,<2.3' if sys.version_info >= (3,) else 'Django>=1.11,<2.0',
+        'Django>=1.11,<2.3' if sys.version_info >= (3, 5) else (
+            'Django>=1.11,<2.1' if sys.version_info >= (3,) else 'Django>=1.11,<2.0'),
         'django-oidc-provider>=0.7.0',  # Version 0.7.0 has a breaking change in response types
         'django-bootstrap3',
         'django-zxcvbn-password',


### PR DESCRIPTION
Debian jessie's Python3 is version 3.4.2, which is no longer supported in Django 2.1.