### PR TITLE
Support MySQL databases with BINLOG_FORMAT = STATEMENT

### DIFF
--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -143,6 +143,8 @@ if _engine == 'mysql':
     # https://django-mysql.readthedocs.io/en/latest/checks.html#django-mysql-w001-strict-mode
     DATABASES['default']['OPTIONS'] = {
         'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+        # Use an isolation level compatible with database replication
+        'isolation_level': "repeatable read",
     }
 
 


### PR DESCRIPTION
The MySQL database replication is currently configured with `BINLOG_FORMAT = STATEMENT`. This is incompatible with Django 2's default isolation level and leads to the following error in `./manage.py
migrate`:

    django.db.utils.OperationalError: (1665, 'Cannot execute statement:
    impossible to write to binary log since BINLOG_FORMAT = STATEMENT
    and at least one table uses a storage engine limited to row-based
    logging. InnoDB is limited to row-logging when transaction isolation
    level is READ COMMITTED or READ UNCOMMITTED.')

Force using `REPEATABLE READ` isolation level for now.