### PR TITLE
Remove Python 3.4 and 3.5 from Travis-CI checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,28 +17,16 @@ matrix:
   include:
     - python: "2.7"
       env: TOXENV=py27-django111
-    - python: "3.4"
-      env: TOXENV=py34-django111
-    - python: "3.5"
-      env: TOXENV=py35-django111
     - python: "3.6"
       env: TOXENV=py36-django111
-    - python: "3.4"
-      env: TOXENV=py34-django20
-    - python: "3.5"
-      env: TOXENV=py35-django20
     - python: "3.6"
       env: TOXENV=py36-django20
     - python: "3.7"
       env: TOXENV=py37-django20
-    - python: "3.5"
-      env: TOXENV=py35-django21
     - python: "3.6"
       env: TOXENV=py36-django21
     - python: "3.7"
       env: TOXENV=py37-django21
-    - python: "3.5"
-      env: TOXENV=py35-django22
     - python: "3.6"
       env: TOXENV=py36-django22
     - python: "3.7"


### PR DESCRIPTION
These versions are no longer provided by Travis-CI.