### PR TITLE
Add groups permission as an available scope in oidc provider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,9 @@ Features (planned)
 Configuring a development environment
 -------------------------------------
 
+Dependencies:
+gettext
+
 Run the following commands in order to setup a development environment on a local computer::
 
     make update

--- a/xorgauth/accounts/oidc_provider_settings.py
+++ b/xorgauth/accounts/oidc_provider_settings.py
@@ -27,6 +27,10 @@ class XorgScopeClaims(ScopeClaims):
         _("X Groups"),
         _("The list of the X Groups you belong to")
     )
+    info_xorg_groups_perm = (
+        _("X Groups Perms"),
+        _("The list of the X Groups you belong to, suffix with admin if you are an admin")
+    )
     info_xorg_study_years = (
         _("Study year"),
         _("The year of your study at the Ecole polytechnique")
@@ -44,6 +48,18 @@ class XorgScopeClaims(ScopeClaims):
         groups = [membership.group for membership in self.user.groups.all()]
         dic = {
             'x_groups': [g.shortname for g in groups]
+        }
+        return dic
+
+    def scope_xorg_groups_perm(self):
+        groups = []
+        for g in self.user.groups.all():
+            name = g.group.shortname
+            groups.append(name)
+            if g.perms == 'admin':
+                groups.append(name + '_admin')
+        dic = {
+            'x_groups_perm': groups
         }
         return dic
 


### PR DESCRIPTION
`x_groups` gives you the groups of an user but you don't know if it is an admin or a member

add `x_groups_perm` to add  a `_admin` group for admin

```json
{
  "sub": "admi.nistrateur.1942",
  "name": "Admi Nistrateur",
  "email": "admi.nistrateur@m4x.org",
  "study_years": [
    "X1942"
  ],
  "x_groups": [
    "1942",
    "Polytechnique.org",
    "X-Informatique"
  ],
  "x_groups_perm": [
    "1942",
    "Polytechnique.org",
    "Polytechnique.org_admin",
    "X-Informatique"
  ]
}
```

This allows to easily match groups with other tools