### PR TITLE
Work around invalid AX OIDC queries

### DIFF
--- a/xorgauth/middleware.py
+++ b/xorgauth/middleware.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) Polytechnique.org
+# This code is distributed under the Affero General Public License version 3
+
+
+class AXOIDCFixerMiddleware:
+    """
+    Middleware used for fixing invalid AX OIDC requests.
+
+    Those requests suffer from an invalid level of URL encoding: parameters are
+    sent as `&amp;client_id=123456` instead of `&client_id=123456`.
+
+    Remove those extra &amp;
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if (
+            request.path.startswith("/openid/authorize")
+            and request.method == "GET"
+            and "amp;client_id" in request.GET
+        ):
+            new_get = request.GET.copy()
+
+            for key in request.GET.keys():
+                if key.startswith("amp;"):
+                    good_key = key[4:]
+                    # A key might occur several times, copy all its values.
+                    for value in new_get.pop(key):
+                        new_get.appendlist(good_key, value)
+            request.GET = new_get
+        return self.get_response(request)

--- a/xorgauth/settings.py
+++ b/xorgauth/settings.py
@@ -75,6 +75,7 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
+    'xorgauth.middleware.AXOIDCFixerMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
Alumnforce performs HTML escaping on the OIDC authorization query. This is invalid, and refused by compliant implementations of OIDC.

Until that is fixed, silently replace '&amp;' with '&' in their query.

NB: If they perform HTML escaping on other parameters of the URL, this middleware will have to be updated.