### PR TITLE
Replace deprecated crypt by passlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'django-bootstrap5',
         'django_zxcvbn_password',
         'getconf',
+        'passlib'
     ],
     setup_requires=[
         'setuptools>=0.8',

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import crypt
 import sys
+from passlib.hash import sha512_crypt
 
 from django.contrib import auth
 from django.core import mail
@@ -150,7 +150,7 @@ class AuthenticationTests(TestCase):
         self.vaneau.set_password('Depuis Vaneau!')
         self.vaneau.save()
         gapps_password = self.vaneau.gapps_password.password
-        self.assertEqual(crypt.crypt('Depuis Vaneau!', gapps_password), gapps_password)
+        self.assertEqual(sha512_crypt.hash('Depuis Vaneau!', salt=gapps_password), gapps_password)
 
         password = 'Mot de passe différent?'
         self.vaneau.set_password(password)
@@ -159,7 +159,7 @@ class AuthenticationTests(TestCase):
         gapps_password = self.vaneau.gapps_password.password
         if sys.version_info < (3,):
             password = password.encode('utf-8')
-        self.assertEqual(crypt.crypt(password, gapps_password), gapps_password)
+        self.assertEqual(sha512_crypt.hash(password, salt=gapps_password), gapps_password)
 
     def test_password_reset_form(self):
         """Test using the password reset form"""

--- a/xorgauth/accounts/password_validators.py
+++ b/xorgauth/accounts/password_validators.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) Polytechnique.org
 # This code is distributed under the Affero General Public License version 3
-import crypt
 import sys
+from passlib.hash import sha512_crypt
 
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.crypto import get_random_string
@@ -19,9 +19,9 @@ class GoogleAppsPasswordValidator(object):
     def password_changed(self, raw_password, user):
         # Hash the password in a way compatible with Google Apps: crypt with $6
         if sys.version_info >= (3,):
-            password = crypt.crypt(raw_password, salt=crypt.METHOD_SHA512)
+            password = sha512_crypt.hash(raw_password, salt=crypt.METHOD_SHA512)
         else:
-            password = crypt.crypt(raw_password.encode('utf-8'), '$6$' + get_random_string(16))
+            password = sha512_crypt.hash(raw_password.encode('utf-8'), '$6$' + get_random_string(16))
         try:
             user.gapps_password.password = password
         except ObjectDoesNotExist:

--- a/xorgauth/accounts/views.py
+++ b/xorgauth/accounts/views.py
@@ -1,5 +1,5 @@
-import crypt
 import json
+from passlib.hash import sha512_crypt
 
 from django.conf import settings
 from django.contrib import messages
@@ -74,7 +74,7 @@ class SyncAxData(View):
             return HttpResponseBadRequest("Unable to load request")
 
         # data['secret'] is a password for authenticating the data provider
-        digest = crypt.crypt(data.get('secret', ''), settings.AX_SYNC_SECRET_CRYPT)
+        digest = sha512_crypt.hash(data.get('secret', ''), salt=settings.AX_SYNC_SECRET_CRYPT)
         if not constant_time_compare(digest, settings.AX_SYNC_SECRET_CRYPT):
             return HttpResponseForbidden("Unauthenticated")
 


### PR DESCRIPTION
From https://docs.python.org/3/library/crypt.html
Deprecated since version 3.11, removed in version 3.13.